### PR TITLE
Temporarily disables atomics on clang, and sets up some compilation flags.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,8 +36,8 @@ OPTION(config_DEBUG "Include debugging information" ON)
 OPTION(config_OPTIM "Optimizations" OFF)
 OPTION(config_COVERAGE "Build with test coverage" OFF)
 
-# Toplevel compile options, for GCC.
-IF(CMAKE_C_COMPILER_ID STREQUAL "GNU")
+# Toplevel compile options, for Clang and GCC.
+IF(CMAKE_C_COMPILER_ID MATCHES "Clang|GNU")
   IF(config_DEBUG)
     ADD_COMPILE_OPTIONS(-ggdb -DDEBUG)
   ENDIF(config_DEBUG)

--- a/atomic.c
+++ b/atomic.c
@@ -22,6 +22,14 @@
 #include "atomic.h"
 #include "test.h"
 
+#if defined(__cplusplus) || defined(__clang__)
+
+const bs_test_case_t          bs_atomic_test_cases[] = {
+    { 0, NULL, NULL }
+};
+
+#else  // defined(__cplusplus) || !defined(__clang__)
+
 /* == Atomic tests ========================================================= */
 
 static void bs_atomic_test_int32(bs_test_t *test_ptr);
@@ -87,4 +95,6 @@ void bs_atomic_test_int64(bs_test_t *test_ptr)
                                           0x0807060504030201));
     BS_TEST_VERIFY_EQ(test_ptr, 0x1122334455667788, bs_atomic_int64_get(&a));
 }
+#endif
+
 /* == End of atomic.c ===================================================== */

--- a/atomic.h
+++ b/atomic.h
@@ -25,14 +25,14 @@
 
 #include <stdint.h>
 
-#if defined(__cplusplus)
+#if defined(__cplusplus) || defined(__clang__)
 
 // C++ (gcc) is not compatible with <stdatomic.h>. When using C++, please
 // resort to using C++ STL <atomic> definitions instead.
 //
 // Therefore, the __cplusplus #if is just an empty block.
 
-#else  // defined(__cplusplus)
+#else  // defined(__cplusplus) || defined(__clang__)
 
 /* == Types and Definitions ================================================ */
 
@@ -460,10 +460,10 @@ static inline void bs_atomic_int64_xchg(bs_atomic_int64_t *a_ptr,
 #endif
 }
 
+#endif  // defined(__cplusplus) || defined(__clang__)
+
 /** Unit tests. */
 extern const bs_test_case_t   bs_atomic_test_cases[];
-
-#endif  /// defined(__cplusplus)
 
 #endif /* __LIBBASE_ATOMIC_H__ */
 /* == End of atomic.h ====================================================== */


### PR DESCRIPTION
This will remedy issue #7 for now. Will need to look into the problem of atomic.[c|h] separately.